### PR TITLE
Add King Charles III Coronation day to UK holidays

### DIFF
--- a/national_holidays.gemspec
+++ b/national_holidays.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'national_holidays'
-  s.version     = '1.17.11'
-  s.date        = '2022-09-14'
+  s.version     = '1.17.12'
+  s.date        = '2022-11-08'
   s.summary     = 'National Holidays for 95 countries'
   s.description = 'Uses config from the national-holidays-config project to provide access to national holiday data across 95 countries'
   s.authors     = ['Alex Balhatchet']


### PR DESCRIPTION
Adds the coronation of King Charles III to UK public holidays.