### PR TITLE
Add St Andrew's Day

### DIFF
--- a/national_holidays.gemspec
+++ b/national_holidays.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'national_holidays'
-  s.version     = '1.17.17'
-  s.date        = '2023-03-29'
+  s.version     = '1.17.18'
+  s.date        = '2023-04-06'
   s.summary     = 'National Holidays for 95 countries'
   s.description = 'Uses config from the national-holidays-config project to provide access to national holiday data across 95 countries'
   s.authors     = ['Alex Balhatchet']


### PR DESCRIPTION
We were using QPP for Scotland including St Andrew's day, when QPP doesn't actually include St Andrew's Day. I emailed QPP and they said they don't include St Andrew's Day. For this reason, we're moving Scotland Including St Andrew's Day to use the gem.

Email reply below:

Despite this feast being declared a bank holiday more than 15 years ago, “banks are not required to close and employers are not obliged to give their workers a day off” (https://www.thescottishsun.co.uk/news/scottish-news/9799801/st-andrews-day-scotland-bank-holiday-2/ and https://www.heraldscotland.com/news/23137743.st-andrews-day-bank-holiday-will-get-day-off/).

Based on this, we do not include it in our list (with the blessing of our 2 largest diary publishing clients, Charles Letts based in Edinburgh and Collins-Debden based in Glasgow), despite the fact that our family loves Scotland and that our annual trip to Arran, Oban, Islay and the Highlands is the high point of our year.
