### PR TITLE
Upgrade countries gem to 5.7 from 2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,31 +2,24 @@ PATH
   remote: .
   specs:
     national_holidays (1.17.21)
-      countries (~> 2.1)
+      countries (~> 5.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    concurrent-ruby (1.2.2)
-    countries (2.1.4)
-      i18n_data (~> 0.8.0)
-      money (~> 6.9)
-      sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
-    i18n (1.14.1)
-      concurrent-ruby (~> 1.0)
-    i18n_data (0.8.0)
-    minitest (5.16.3)
-    money (6.16.0)
-      i18n (>= 0.6.4, <= 2)
-    parallel (1.22.1)
-    parser (3.1.2.1)
+    countries (5.7.1)
+      unaccent (~> 0.3)
+    minitest (5.20.0)
+    parallel (1.24.0)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rainbow (3.1.1)
     rake (12.3.3)
-    regexp_parser (2.6.1)
-    rexml (3.2.5)
+    regexp_parser (2.8.3)
+    rexml (3.2.6)
     rubocop (0.93.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
@@ -36,12 +29,11 @@ GEM
       rubocop-ast (>= 0.6.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.23.0)
-      parser (>= 3.1.1.0)
-    ruby-progressbar (1.11.0)
-    sixarm_ruby_unaccent (1.2.2)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unaccent (0.4.0)
     unicode-display_width (1.8.0)
-    unicode_utils (1.4.0)
 
 PLATFORMS
   arm64-darwin-21

--- a/lib/national_holidays/country.rb
+++ b/lib/national_holidays/country.rb
@@ -14,7 +14,7 @@ class NationalHolidays
 
     def initialize(code)
       @code = code.to_sym
-      @name = ISO3166::Country.new(code).name
+      @name = ISO3166::Country.new(code).iso_short_name
     end
 
     def regions

--- a/national_holidays.gemspec
+++ b/national_holidays.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.files       = Dir.glob("{bin,lib,test}/**/*") + Dir.glob("national-holidays-config/conf/*/*.yml") + %w(LICENSE.txt README.md Rakefile)
 
-  s.add_runtime_dependency 'countries', '~>2.1'
+  s.add_runtime_dependency 'countries', '~>5.7'
 
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'rake', '~> 12.3'

--- a/national_holidays.gemspec
+++ b/national_holidays.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'national_holidays'
-  s.version     = '1.17.21'
-  s.date        = '2023-06-06'
+  s.version     = '2.0'
+  s.date        = '2024-01-16'
   s.summary     = 'National Holidays for 95 countries'
   s.description = 'Uses config from the national-holidays-config project to provide access to national holiday data across 95 countries'
   s.authors     = ['Alex Balhatchet']


### PR DESCRIPTION
Huge version change as the countries gem is extremely out of date. 

The changelog for the countries gem describes needing an upgrade process for the upgrade to 4.2, and for the upgrade to 5.0. As such, I've made a major version change to this change, to reflect that these were _breaking changes_ and may cause issues elsewhere.

The only breaking change within this gem itself for `national-holidays-ruby` is that `.name` is now deprecated on the countries gem. This means that instead, we're using `.iso_short_name`. There is also `.common_name`, and `.iso_long_name`, but these do not match the previous expected behaviours. Common name shortens `United Kingdom of Great Britain and Northern Ireland` to simply `United Kingdom`, whereas long names add `The` to country names. `.iso_short_name` is the closest to existing functionality. 

The other breaking change for 5.0 breaks `find_by` methods, but these are unused here. 

UPGRADE.md for the countries gem: https://github.com/countries/countries/blob/master/UPGRADE.md
Changelog for countries gem: https://github.com/countries/countries/blob/master/CHANGELOG.md