### PR TITLE
Update countries gem from 6.0.1 => 7.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    national_holidays (3.0)
-      countries (~> 6.0)
+    national_holidays (4.0.0)
+      countries (~> 7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    countries (6.0.0)
+    countries (7.0.0)
       unaccent (~> 0.3)
     minitest (5.20.0)
     parallel (1.24.0)

--- a/national_holidays.gemspec
+++ b/national_holidays.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'national_holidays'
-  s.version     = '3.0.1'
-  s.date        = '2024-05-23'
+  s.version     = '4.0.0'
+  s.date        = '2024-09-30'
   s.summary     = 'National Holidays for 95 countries'
   s.description = 'Uses config from the national-holidays-config project to provide access to national holiday data across 95 countries'
   s.authors     = ['Alex Balhatchet']
@@ -12,9 +12,9 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.files       = Dir.glob("{bin,lib,test}/**/*") + Dir.glob("national-holidays-config/conf/*/*.yml") + %w(LICENSE.txt README.md Rakefile)
 
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '>= 3.1'
 
-  s.add_runtime_dependency 'countries', '~>6.0'
+  s.add_runtime_dependency 'countries', '~>7.0'
 
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
We need to update the countries gem in the Charlie app but it is limited to 6.0.1 because of the national holidays gem. So we are updating our national holidays gem to use the latest version of the countries gem.

Breaking changes:
* The countries gem will no longer support Ruby 3.0, so we have updated the minimum version to be 3.1
* The #state method has been deprecated in the countries gem, but we do not use that in our code.