### PR TITLE
Update countries gem from 7.0 => 8.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    national_holidays (4.0.1)
-      countries (~> 7.0)
+    national_holidays (5.0.0)
+      countries (~> 8.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    countries (7.1.1)
+    countries (8.0.3)
       unaccent (~> 0.3)
     minitest (5.20.0)
     parallel (1.24.0)
@@ -48,4 +48,4 @@ DEPENDENCIES
   rubocop (~> 0.56)
 
 BUNDLED WITH
-   2.3.11
+   2.6.9

--- a/lib/national_holidays/country.rb
+++ b/lib/national_holidays/country.rb
@@ -14,7 +14,7 @@ class NationalHolidays
 
     def initialize(code)
       @code = code.to_sym
-      @name = ISO3166::Country.new(code).iso_short_name
+      @name = ISO3166::Country.new(code).common_name
     end
 
     def regions

--- a/national_holidays.gemspec
+++ b/national_holidays.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'national_holidays'
-  s.version     = '4.0.1'
-  s.date        = '2025-02-28'
+  s.version     = '5.0.0'
+  s.date        = '2025-07-23'
   s.summary     = 'National Holidays for 95 countries'
   s.description = 'Uses config from the national-holidays-config project to provide access to national holiday data across 95 countries'
   s.authors     = ['Alex Balhatchet']
@@ -12,9 +12,9 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.files       = Dir.glob("{bin,lib,test}/**/*") + Dir.glob("national-holidays-config/conf/*/*.yml") + %w(LICENSE.txt README.md Rakefile)
 
-  s.required_ruby_version = '>= 3.1'
+  s.required_ruby_version = '>= 3.4'
 
-  s.add_runtime_dependency 'countries', '~>7.0'
+  s.add_runtime_dependency 'countries', '~> 8.0'
 
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'rake', '~> 12.3'

--- a/test/test_national_holidays_country.rb
+++ b/test/test_national_holidays_country.rb
@@ -10,7 +10,7 @@ class NationalHolidaysCountryTest < Minitest::Test
   end
 
   def test_name
-    assert_equal 'United Kingdom of Great Britain and Northern Ireland', NationalHolidays::Country.new(:gb).name
+    assert_equal 'United Kingdom', NationalHolidays::Country.new(:gb).name
   end
 
   def test_regions


### PR DESCRIPTION
We need to update the countries gem in the Charlie app but it is limited to 7.0 because of the national holidays gem. So we are updating our national holidays gem to use the latest version of the countries gem.

[changelog](https://github.com/countries/countries/blob/master/CHANGELOG.md)

**Breaking changes:**
* Drops support for Ruby 3.1 so have updated the require version to 3.4
* Changes to translation hashes to sometimes use symbol keys instead of strings (see commit [here](https://github.com/countries/countries/pull/884)) All tests in this gem are still passing, however I will make sure to carefully test the code related to public holidays in the Charlie app before updating the countries gem there too.

* There is also a potential breaking change in the way the `find_subdivision_by_name` method works, but we don't use that in this gem or the Charlie app.